### PR TITLE
Fix for panic when Message-ID is not supplied and From field fails to parse

### DIFF
--- a/message.go
+++ b/message.go
@@ -286,7 +286,11 @@ func (m *Message) Bytes() []byte {
 	}
 	// Message-ID; randomly generated value if missing in the Header map.
 	if m.MessageID() == "" {
-		fmt.Fprintf(output, "Message-ID: <%s.%s>", randomString(messageIDLength), m.From().Address)
+		address := m.From()
+		if address == nil {
+			address = &Address{Name: "", Address: "unknown@unknown"}
+		}
+		fmt.Fprintf(output, "Message-ID: <%s.%s>", randomString(messageIDLength), address)
 		output.WriteString(crlf)
 	}
 	output.WriteString(crlf)


### PR DESCRIPTION
When Message-ID is not supplied, if the From field fails to parse, the code dereferences a nil.
This change checks the result of From(), and if it's nil it uses an address of "unknown@unknown" instead.